### PR TITLE
fix(changelog): use the commit from url instead of oid as changelog base

### DIFF
--- a/cmd/internal/github/graphql.go
+++ b/cmd/internal/github/graphql.go
@@ -113,6 +113,10 @@ type GQLRefTarget struct {
 	Oid       string `json:"oid"`
 }
 
+func (r GQLRefTarget) Commit() string {
+	return r.CommitUrl[strings.LastIndex(r.CommitUrl, "/")+1:]
+}
+
 type GQLClient struct {
 	Token string
 	Cl    *github.Client
@@ -233,7 +237,8 @@ query ($owner: String!, $name: String!, $ref: String!) {
 	if err != nil {
 		return "", err
 	}
-	return res.Data.Repository.Ref.Target.Oid, nil
+	// In some cases the oid doesn't match the github commit so let's extract the commit from the url.
+	return res.Data.Repository.Ref.Target.Commit(), nil
 }
 
 func (c GQLClient) graphqlQuery(query string, variables map[string]interface{}) (GQLOutput, error) {

--- a/cmd/release-tool/release.go
+++ b/cmd/release-tool/release.go
@@ -57,8 +57,16 @@ TODO summary of some simple stuff.
 				header = strings.SplitN(release.GetBody(), "## Changelog", 2)[0] + "## Changelog\n\n"
 			}
 			sbuilder.WriteString(header)
+			_, err := fmt.Fprintf(cmd.OutOrStdout(), "getting changelog from %s on repo %s and branch %s\n", prevVersion, config.repo, branch)
+			if err != nil {
+				return err
+			}
 			changelog, err := getChangelog(gqlClient, config.repo, branch, prevVersion)
 			if err != nil {
+				return err
+			}
+			if len(changelog) == 0 {
+				_, err := fmt.Fprintf(cmd.OutOrStdout(), "no changelog\n")
 				return err
 			}
 			for _, v := range changelog {


### PR DESCRIPTION
Sometimes the oid of the target of a tag is not the git hash. This would cause problems for kuma 2.2.0 for example and the release generation would fail.

We now extract the git hash from the commitUrl so that it's always a proper git hash.

Fix #20