### PR TITLE
fix(version-file): ignore prereleases

### DIFF
--- a/cmd/release-tool/version_file.go
+++ b/cmd/release-tool/version_file.go
@@ -38,6 +38,9 @@ var versionFile = &cobra.Command{
 		byVersion := map[string][]github.GQLRelease{}
 		for i := range res {
 			curVersion := res[i].SemVer()
+			if curVersion.Prerelease() != "" {
+				continue // Ignore prereleases
+			}
 			if curVersion.LessThan(minVersionVer) {
 				continue
 			}


### PR DESCRIPTION
This would create problematic changes like: https://github.com/kumahq/kuma/pull/9889