### PR TITLE
feat(version_file): add option to support LTS version

### DIFF
--- a/cmd/internal/github/graphql.go
+++ b/cmd/internal/github/graphql.go
@@ -70,6 +70,10 @@ func (r GQLRelease) ExtractReleaseDate() (time.Time, error) {
 	return r.PublishedAt, nil
 }
 
+func (r GQLRelease) IsLTS() bool {
+	return regexp.MustCompile("^> LTS").MatchString(r.Description)
+}
+
 // Branch branch that this release was first on
 func (r GQLRelease) Branch() string {
 	// In theory we could extract this from the tag but let's keep this simple

--- a/cmd/release-tool/version_file.go
+++ b/cmd/release-tool/version_file.go
@@ -16,11 +16,12 @@ import (
 )
 
 var (
-	lifetimeMonths int
-	edition        string
-	minVersion     string
-	activeBranches bool
-	useLabelForDev bool
+	lifetimeMonths    int
+	ltsLifetimeMonths int
+	edition           string
+	minVersion        string
+	activeBranches    bool
+	useLabelForDev    bool
 )
 
 var versionFile = &cobra.Command{
@@ -50,7 +51,7 @@ var versionFile = &cobra.Command{
 		}
 		var out []versionfile.VersionEntry
 		for releaseName, releases := range byVersion {
-			res, err := versionfile.BuildVersionEntry(edition, releaseName, lifetimeMonths, releases)
+			res, err := versionfile.BuildVersionEntry(edition, releaseName, lifetimeMonths, ltsLifetimeMonths, releases)
 			if err != nil {
 				return err
 			}
@@ -89,6 +90,7 @@ func init() {
 	versionFile.Flags().StringVar(&config.repo, "repo", "kumahq/kuma", "The repository to query")
 	versionFile.Flags().StringVar(&edition, "edition", "kuma", "The edition of the product")
 	versionFile.Flags().IntVar(&lifetimeMonths, "lifetime-months", 12, "the number of months a version is valid for")
+	versionFile.Flags().IntVar(&ltsLifetimeMonths, "lts-lifetime-months", 24, "the number of months an lts version is valid for")
 	versionFile.Flags().StringVar(&minVersion, "min-version", "1.2.0", "The minimum version to build a version files on")
 	versionFile.Flags().BoolVar(&activeBranches, "active-branches", false, "only output a json with the branches not EOL")
 	versionFile.Flags().BoolVar(&useLabelForDev, "use-label-for-dev", false, "For the master branch infer a version")


### PR DESCRIPTION
In release notes you need to add a `> LTS` entry
this will create a version file with longer EOL so that active-branches and versions file are useful
