### PR TITLE
fix(changelog): exclude open PRs when generating release notes

### DIFF
--- a/cmd/internal/github/graphql.go
+++ b/cmd/internal/github/graphql.go
@@ -100,11 +100,12 @@ type GQLAuthor struct {
 }
 
 type GQLPRNode struct {
-	Author GQLAuthor `json:"author"`
-	Number int       `json:"number"`
-	Title  string    `json:"title"`
-	Body   string    `json:"body"`
-	Merged bool      `json:"merged"`
+	Author      GQLAuthor `json:"author"`
+	Number      int       `json:"number"`
+	Title       string    `json:"title"`
+	Body        string    `json:"body"`
+	Merged      bool      `json:"merged"`
+	MergeCommit GQLCommit `json:"mergeCommit"`
 }
 
 type GQLRef struct {
@@ -113,8 +114,8 @@ type GQLRef struct {
 
 type GQLCommit struct {
 	Oid                    string           `json:"oid"`
-	Message                string           `json:"message"`
-	AssociatedPullRequests GQLAssociatedPRs `json:"associatedPullRequests"`
+	Message                string           `json:"message,omitempty"`
+	AssociatedPullRequests GQLAssociatedPRs `json:"associatedPullRequests,omitempty"`
 }
 
 type GQLRefTarget struct {
@@ -230,6 +231,9 @@ query($name: String!, $owner: String!, $branch: String!) {
                 title
                 body
                 merged
+                mergeCommit {
+                  oid
+                }
               }
             }
           }

--- a/cmd/internal/github/graphql.go
+++ b/cmd/internal/github/graphql.go
@@ -104,6 +104,7 @@ type GQLPRNode struct {
 	Number int       `json:"number"`
 	Title  string    `json:"title"`
 	Body   string    `json:"body"`
+	Merged bool      `json:"merged"`
 }
 
 type GQLRef struct {
@@ -220,7 +221,7 @@ query($name: String!, $owner: String!, $branch: String!) {
           nodes {
             oid
             message
-            associatedPullRequests(first: 1) {
+            associatedPullRequests(first: 100) {
               nodes {
                 author {
                   login
@@ -228,6 +229,7 @@ query($name: String!, $owner: String!, $branch: String!) {
                 number
                 title
                 body
+                merged
               }
             }
           }

--- a/cmd/release-tool/changelog.go
+++ b/cmd/release-tool/changelog.go
@@ -118,10 +118,10 @@ func getChangelog(gqlClient *github.GQLClient, repo string, branch string, tag s
 	}
 	var commitInfos []changeloggenerator.CommitInfo
 	for _, commit := range res {
-		if len(commit.AssociatedPullRequests.Nodes) == 0 {
+		pr := getCommitPR(&commit)
+		if pr == nil {
 			continue
 		}
-		pr := commit.AssociatedPullRequests.Nodes[0]
 		ci := changeloggenerator.CommitInfo{
 			Author:        pr.Author.Login,
 			Sha:           commit.Oid,
@@ -133,6 +133,20 @@ func getChangelog(gqlClient *github.GQLClient, repo string, branch string, tag s
 		commitInfos = append(commitInfos, ci)
 	}
 	return changeloggenerator.New(config.repo, commitInfos)
+}
+
+func getCommitPR(commit *github.GQLCommit) *github.GQLPRNode {
+	if len(commit.AssociatedPullRequests.Nodes) == 0 {
+		return nil
+	}
+
+	for _, prNode := range commit.AssociatedPullRequests.Nodes {
+		if prNode.Merged && strings.Contains(commit.Message, fmt.Sprintf("(#%d)", prNode.Number)) {
+			return &prNode
+		}
+	}
+
+	return nil
 }
 
 func init() {


### PR DESCRIPTION
The release tool may extract change log from open PRs, and this is incorrect. This PR is to fix the issue by making sure the associated PRs are indeed the ones who created commits.

New backport PRs can be created during the patch releasing, it's also possible that folks decide not to merge a PR in a patch release branch.

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)
* Yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
* Yes
