### PR TITLE
fix(openapi): clean up after resolving schema name

### DIFF
--- a/openapi-tool/commands/generate.js
+++ b/openapi-tool/commands/generate.js
@@ -58,6 +58,7 @@ exports.generateFiles = async (argv) => {
                 delete spec.components.schemas.schema
             }
             deepReplace(spec, "$ref", "#/components/schemas/schema", `#/components/schemas/${name}Item`)
+            spec.info['x-ref-schema-name'] = undefined
         }
         return spec
     }))).filter((n) => n !== null);


### PR DESCRIPTION
otherwise we end up with https://github.com/kumahq/kuma/blob/master/docs/generated/openapi.yaml#L6 in a top level

run this locally and got this:

![image](https://github.com/user-attachments/assets/f01ccde4-84d0-44ed-b172-6e9a9039a549)

so I'm assuming this works, although there are no tests in this repo

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
