### PR TITLE
fix(changelog): correctly check if comment ends

### DIFF
--- a/cmd/internal/changeloggenerator/changelog.go
+++ b/cmd/internal/changeloggenerator/changelog.go
@@ -102,7 +102,7 @@ func (ci *CommitInfo) normalize() bool {
 		if strings.HasPrefix(l, "<!--") {
 			inComment = true
 		}
-		if inComment && strings.HasPrefix(l, "-->") {
+		if inComment && strings.HasSuffix(l, "-->") {
 			inComment = false
 		}
 		if !inComment && strings.HasPrefix(l, "> Changelog: ") {


### PR DESCRIPTION
fix: https://github.com/Kong/team-mesh/issues/346

use suffix to check if comment section ends