### PR TITLE
fix(changelog): skip generate changelogs that with "skip" sign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+.idea

--- a/cmd/internal/changeloggenerator/changelog.go
+++ b/cmd/internal/changeloggenerator/changelog.go
@@ -99,6 +99,7 @@ func (ci *CommitInfo) normalize() bool {
 	changelog := ""
 	inComment := false
 	for _, l := range strings.Split(ci.PrBody, "\n") {
+		l = strings.TrimSpace(l)
 		if strings.HasPrefix(l, "<!--") {
 			inComment = true
 		}


### PR DESCRIPTION
The github content has "\r" for each line which makes our character string suffix condition failed. As a result, those PR with "> Changelog: skip" would be kept in the changelog markdown. So, we use trim to remove the terminative extra signs

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits)

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)?
