### PR TITLE
chore: remove .x from versions

### DIFF
--- a/cmd/release-tool/version_file.go
+++ b/cmd/release-tool/version_file.go
@@ -45,7 +45,7 @@ var versionFile = &cobra.Command{
 			if curVersion.LessThan(minVersionVer) {
 				continue
 			}
-			release := fmt.Sprintf("%d.%d.x", curVersion.Major(), curVersion.Minor())
+			release := fmt.Sprintf("%d.%d", curVersion.Major(), curVersion.Minor())
 			byVersion[release] = append(byVersion[release], res[i])
 		}
 		var out []versionfile.VersionEntry


### PR DESCRIPTION
Remove `.x` from versions, we no longer use them in the dev site, just major and minor.

Related [PR](https://github.com/Kong/kong-mesh/pull/7930)


Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
