### PR TITLE
chore(deps): bump oas-toolkit to 0.15.2

### DIFF
--- a/openapi-tool/package-lock.json
+++ b/openapi-tool/package-lock.json
@@ -13,7 +13,7 @@
         "@redocly/openapi-core": "1.2.0",
         "fast-glob": "3.3.1",
         "js-yaml": "4.1.0",
-        "oas-toolkit": "0.7.2"
+        "oas-toolkit": "0.15.2"
       },
       "bin": {
         "openapi": "index.js"
@@ -29,6 +29,22 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "11.9.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.3.tgz",
+      "integrity": "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
       }
     },
     "node_modules/@babel/cli": {
@@ -1918,6 +1934,11 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
+    },
     "node_modules/@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
@@ -2021,9 +2042,9 @@
       }
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.13",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
-      "integrity": "sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ=="
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
     "node_modules/@types/node": {
       "version": "14.18.63",
@@ -2798,6 +2819,11 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
     },
+    "node_modules/lodash.intersection": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.intersection/-/lodash.intersection-4.4.0.tgz",
+      "integrity": "sha512-N+L0cCfnqMv6mxXtSPeKt+IavbOBBSiAEkKyLasZ8BVcP9YXQgxLO12oPR8OyURwKV8l5vJKiE1M8aS70heuMg=="
+    },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
@@ -3098,15 +3124,17 @@
       }
     },
     "node_modules/oas-toolkit": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/oas-toolkit/-/oas-toolkit-0.7.2.tgz",
-      "integrity": "sha512-Lkiqr3DsKrlYKjqIOJNGKDpXe3L6jJSyPqNpbhhPpjqmvAvTJYi2yAEp9qrMshjGUC5ySbyCGHAB/ESYfLTuxw==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/oas-toolkit/-/oas-toolkit-0.15.2.tgz",
+      "integrity": "sha512-BVgD2be0rsQgTbmaCqjGIZsuQS5+XetJfyVCaPnXjP7WDEVXePZkZU41P+dLonejJybaC/IhdH1zkG2gX8Vd5Q==",
       "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^11.7.0",
         "debug": "^4.3.4",
         "js-yaml": "^4.1.0",
         "jsonpath-plus": "^7.2.0",
         "lodash.difference": "^4.5.0",
         "lodash.get": "^4.4.2",
+        "lodash.intersection": "^4.4.0",
         "lodash.isequal": "^4.5.0",
         "lodash.uniqwith": "^4.5.0",
         "mergician": "^1.1.0",

--- a/openapi-tool/package.json
+++ b/openapi-tool/package.json
@@ -17,6 +17,6 @@
     "@redocly/openapi-core": "1.2.0",
     "fast-glob": "3.3.1",
     "js-yaml": "4.1.0",
-    "oas-toolkit": "0.7.2"
+    "oas-toolkit": "0.15.2"
   }
 }


### PR DESCRIPTION
Speeds up oas generation in kuma from 10 minutes to ~0.6 seconds

```
node ../ci-tools/openapi-tool/index.js generate 'build/oapitmp/**/*.yaml' >   0,61s user 0,12s system 120% cpu 0,608 total
```

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes


