### PR TITLE
ci(renovate): use shared security preset and official makefile mgr

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,15 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    ":configMigration",
+    "customManagers:makefileVersions",
     "Kong/public-shared-renovate:backend",
-    "kumahq/kuma//.renovate/security"
-  ],
-  "enabledManagers": [
-    "custom.regex",
-    "dockerfile",
-    "github-actions",
-    "gomod",
-    "npm"
+    "Kong/public-shared-renovate:security-extended(area/security,team:kuma-security-managers)"
   ],
   "ignorePaths": []
 }


### PR DESCRIPTION
## Motivation

The Renovate configuration in ci-tools still referenced the old `kumahq/kuma//.renovate/security` preset, which has been removed and moved to `Kong/public-shared-renovate`. It also used a hand-written setup for Makefile updates instead of the official manager and explicitly listed enabled managers, which is no longer necessary. These issues made the configuration outdated and harder to maintain.

## Implementation information

### Updated presets

- Removed reference to `kumahq/kuma//.renovate/security`  
- Added `Kong/public-shared-renovate:security-extended(area/security,team:kuma-security-managers)`  
- Added `:configMigration` to ensure the configuration stays compatible with future Renovate versions  

### Updated managers

- Added `customManagers:makefileVersions` to switch from a hand-written manager setup to the official one  
- Removed explicit `enabledManagers` list to rely on Renovate defaults  

## Result

- Renovate configuration now loads successfully and uses shared presets  
- Security updates are handled consistently through the shared preset  
- Makefile version bumps are managed by the official manager  
- Configuration is smaller, cleaner, and easier to maintain  

## Additional documentation

Closes https://github.com/kumahq/ci-tools/issues/109
