### PR TITLE
feat(release-tool): emit baseBranchPatterns for active branches

### DIFF
--- a/cmd/release-tool/version_file.go
+++ b/cmd/release-tool/version_file.go
@@ -23,6 +23,10 @@ var (
 	activeBranches    bool
 )
 
+type ActiveBranches struct {
+	BaseBranchPatterns []string `json:"baseBranchPatterns"`
+}
+
 var versionFile = &cobra.Command{
 	Use:   "version-file",
 	Short: "Recreate the versions.yaml using github releases",
@@ -76,7 +80,7 @@ var versionFile = &cobra.Command{
 					branches = append(branches, v.Branch)
 				}
 			}
-			return json.NewEncoder(cmd.OutOrStdout()).Encode(branches)
+			return json.NewEncoder(cmd.OutOrStdout()).Encode(ActiveBranches{branches})
 		}
 		return yaml.NewEncoder(cmd.OutOrStdout()).Encode(out)
 	},


### PR DESCRIPTION
## Motivation

Adopt the MADR "Change active-branches.json Into a Renovate Preset" (kumahq/kuma#14572). We need a single file that scripts and Renovate can consume. Moving from a raw array to `{ "baseBranchPatterns": [...] }` makes the file a valid Renovate preset. This enables OSV alerts and controlled updates on release branches while keeping the change low risk.

## Implementation information

The release-tool now wraps the active branches list in an `ActiveBranches` struct and encodes `{ "baseBranchPatterns": [ ... ] }` when `--active-branches` is used. No change to how branches are collected or filtered. This aligns with the MADR choice to switch to an object and update all consumers.

Migration guidance mirrors the MADR: during rollout, consumers can be tolerant to both shapes via `jq` and later read `.baseBranchPatterns` directly.

## Supporting documentation

- MADR: https://github.com/kumahq/kuma/pull/14572