### PR TITLE
ci(deps): align Renovate with Kong presets, bump Go to 1.25.1, update…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kumahq/ci-tools
 
-go 1.23.4
+go 1.25.1
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
@@ -12,7 +12,7 @@ require (
 
 require (
 	github.com/google/go-querystring v1.1.0 // indirect
-	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.9 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
+github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -19,6 +21,8 @@ github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=
 github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4XaB0=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
+github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,48 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    ":configMigration",
-    "customManagers:makefileVersions",
-    "Kong/public-shared-renovate:backend",
-    "Kong/public-shared-renovate:security-extended(area/security,team:kuma-security-managers)"
+    "Kong/public-shared-renovate",
+    "Kong/public-shared-renovate//overrides/security-labels(area/security)",
+    "Kong/public-shared-renovate//overrides/security-reviewers(team:kuma-security-managers)",
+    ":automergeRequireAllStatusChecks",
+    ":automergeMinor",
+    ":automergePatch",
+    ":combinePatchMinorReleases",
+    ":disableRateLimiting",
+    ":semanticCommitTypeAll(chore)",
+    "docker:pinDigests"
   ],
-  "ignorePaths": []
+  "ignorePresets": [
+    ":ignoreModulesAndTests",
+    "customManagers:dockerfileVersions",
+    "customManagers:helmChartYamlAppVersions",
+    "customManagers:tfvarsVersions"
+  ],
+  "enabledManagers": [
+    "custom.regex",
+    "dockerfile",
+    "github-actions",
+    "gomod",
+    "npm"
+  ],
+  "schedule": ["at any time"],
+  "automergeStrategy": "squash",
+  "internalChecksFilter": "strict",
+  "keepUpdatedLabel": "renovate/keep-updated",
+  "rebaseWhen": "conflicted",
+  "prTitleStrict": true,
+  "vulnerabilityAlerts": {"commitMessageSuffix": ""},
+  "packageRules": [
+    {
+      "description": [
+        " Catch-all rule that applies the standard commit message format for all dependencies",
+        "",
+        " This rule extends the shared baseline preset to ensure consistent commit message",
+        " action/topic/extra rendering across all updates. It must be the last packageRule",
+        " in renovate.json, so it takes precedence after any more specific rules."
+      ],
+      "matchDepNames": "*",
+      "extends": ["Kong/public-shared-renovate//scoped/kuma/commit-message-baseline"]
+    }
+  ]
 }


### PR DESCRIPTION
## Motivation

Bring this repo in line with Kong shared Renovate policies for more predictable updates and security labeling. Improve automation by enabling managers we actually use and by allowing safe auto merges. Upgrade Go to 1.25.1 to pick up the latest fixes. Refresh indirect dependencies so builds stay consistent with the new toolchain and upstream libraries.

## Implementation information

- Renovate: switched to `Kong/public-shared-renovate` and security overrides, enabled the relevant managers, tightened PR formatting, and set automerge behavior with required checks and squash. Added a final catch all commit message baseline for consistent titles across updates
- Go: updated `go.mod` `go 1.25.1` and regenerated `go.sum` via `go mod tidy` semantics
- Deps: bumped indirect `hashicorp/errwrap` and `spf13/pflag` to their latest patch releases that are compatible with the current tree