### PR TITLE
fix(changelog): fallback to commit from master in case of lack of tag

### DIFF
--- a/cmd/internal/github/graphql.go
+++ b/cmd/internal/github/graphql.go
@@ -284,6 +284,15 @@ query($name: String!, $owner: String!, $branch: String!) {
 	}
 }
 
+func (c GQLClient) MergeBase(ctx context.Context, repo, base, head string) (string, error) {
+	owner, name := SplitRepo(repo)
+	comparison, _, err := c.Cl.Repositories.CompareCommits(ctx, owner, name, base, head, nil)
+	if err != nil {
+		return "", err
+	}
+	return comparison.GetMergeBaseCommit().GetSHA(), nil
+}
+
 func (c GQLClient) CommitByRef(repo, tag string) (string, error) {
 	owner, name := SplitRepo(repo)
 	res, err := c.graphqlQuery(`

--- a/cmd/release-tool/changelog.go
+++ b/cmd/release-tool/changelog.go
@@ -107,8 +107,11 @@ It will then output a changelog with all PRs with the same changelog grouped tog
 			return err
 		}
 
-		// Use warnOnNormalize=true since config.fromTag is user-provided
-		out, err := getChangelog(gqlClient, config.repo, config.branch, config.fromTag, true)
+		fromCommit, err := gqlClient.CommitByRef(config.repo, NormalizeVersionTagWithWarning(config.fromTag))
+		if err != nil {
+			return err
+		}
+		out, err := getChangelog(gqlClient, config.repo, config.branch, fromCommit)
 		if err != nil {
 			return err
 		}
@@ -129,22 +132,8 @@ It will then output a changelog with all PRs with the same changelog grouped tog
 	},
 }
 
-func getChangelog(gqlClient *github.GQLClient, repo string, branch string, tag string, warnOnNormalize bool) (changeloggenerator.Changelog, error) {
-	// Normalize tag to ensure correct v-prefix based on kumahq/kuma conventions
-	var normalizedTag string
-	if warnOnNormalize {
-		normalizedTag = NormalizeVersionTagWithWarning(tag)
-	} else {
-		normalizedTag = NormalizeVersionTag(tag)
-	}
-
-	// Retrieve data from github
-	commit, err := gqlClient.CommitByRef(repo, normalizedTag)
-	if err != nil {
-		return nil, err
-	}
-	// Deal with pagination
-	res, err := gqlClient.HistoryGraphQl(repo, branch, commit)
+func getChangelog(gqlClient *github.GQLClient, repo string, branch string, fromCommit string) (changeloggenerator.Changelog, error) {
+	res, err := gqlClient.HistoryGraphQl(repo, branch, fromCommit)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/release-tool/release.go
+++ b/cmd/release-tool/release.go
@@ -63,16 +63,38 @@ TODO summary of some simple stuff.
 			return err
 		}
 
-		// Normalize the previous version tag for display and lookup
 		prevTag := NormalizeVersionTag(prevVersion.String())
+
+		fromCommit, err := gqlClient.CommitByRef(config.repo, prevTag)
+		if err != nil {
+			return err
+		}
+
+		// For .0 releases, the prev tag lives on a sibling branch that may not be merged back
+		// into master. Detect this by checking if the tag commit is reachable from the current
+		// branch (merge-base of tag and branch equals the tag itself). If not, fall back to the
+		// merge-base of the two release branches as the cutoff.
+		if version.Patch() == 0 && fromCommit != "" {
+			mergeBase, err := gqlClient.MergeBase(cmd.Context(), config.repo, fromCommit, branch)
+			if err != nil {
+				return err
+			}
+			if mergeBase != fromCommit {
+				prevBranch := fmt.Sprintf("release-%d.%d", version.Major(), version.Minor()-1)
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "tag %s not reachable from %s, falling back to merge-base with %s\n", prevTag, branch, prevBranch)
+				fromCommit, err = gqlClient.MergeBase(cmd.Context(), config.repo, prevBranch, branch)
+				if err != nil {
+					return err
+				}
+			}
+		}
 
 		_, err = fmt.Fprintf(cmd.OutOrStdout(), "getting changelog from %s on repo %s and branch %s\n", prevTag, config.repo, branch)
 		if err != nil {
 			return err
 		}
 
-		// Use warnOnNormalize=false since prevVersion is auto-derived, not user-provided
-		changelog, err := getChangelog(gqlClient, config.repo, branch, prevTag, false)
+		changelog, err := getChangelog(gqlClient, config.repo, branch, fromCommit)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Generating the 2.14.0 changelog for kong-mesh returned 202k characters — every commit in the repo's history — instead of just the commits since v2.13.0.

  The root cause is a branching difference. `kumahq/kuma` merges release branches back into master, so any release tag is reachable from the next branch's ancestry. The existing tag-based cutoff works there because walking release-2.14's history finds the `v2.13.0` tag. `kong-mesh` didn't merge back, so the v2.13.0 SHA only lives on release-2.13. Walking release-2.14
  never encounters it, and the walker falls through with no cutoff.

  The fix adds a reachability check for `.0` releases. After resolving the previous tag to a commit, the tool calls `MergeBase(tagSHA, branch)` and checks whether the result equals tagSHA. If it does, the tag is an ancestor of the current branch and the existing behavior applies. If not, the tool logs a warning and falls back to MergeBase(prevReleaseBranch, branch)
  to find where the two branches diverged. Patch releases skip this check — the previous patch tag always lives on the same branch.

  Three files changed:
  - graphql.go: new MergeBase() wrapping GitHub's compare API
  - changelog.go: getChangelog() takes a commit SHA directly; callers resolve tag→commit (no behavior change)
  - release.go: reachability check and branch-diverge fallback for .0 releases